### PR TITLE
Added installing unzip in notebook assets

### DIFF
--- a/assets/setup-ngc.sh
+++ b/assets/setup-ngc.sh
@@ -16,6 +16,7 @@ echo \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update
 sudo apt-get install -y docker-ce-cli
+sudo apt-get install unzip
 # Install NGC CLI (with suppressed output)
 echo "Installing NGC CLI..."
 (


### PR DESCRIPTION
If user does not have `unzip` installed then NGC script to download NGC won't work. 