### PR TITLE
fix: upgrade dependencies to address Nspect vulnerabilities

### DIFF
--- a/assets/reranker-launchable/requirements.txt
+++ b/assets/reranker-launchable/requirements.txt
@@ -1,9 +1,9 @@
 faiss_cpu==1.8.0
 fastapi==0.128.0
-langchain==1.2.6
+langchain==1.3.1
 langchain-community==0.4.1
-langchain-core==1.2.7
+langchain-core==1.4.0
 langchain-nvidia-ai-endpoints==1.0.2
 numpy==1.26.4
 sentence-transformers==2.2.2
-unstructured==0.17.2
+unstructured==0.22.28


### PR DESCRIPTION
### Vulnerabilities addressed

- [BDSA-2026-1535](https://nspect.nvidia.com/vulnerability?id=BDSA-2026-1535)
- [BDSA-2025-77504](https://nspect.nvidia.com/vulnerability?id=BDSA-2025-77504)
- [BDSA-2025-29575](https://nspect.nvidia.com/vulnerability?id=BDSA-2025-29575)